### PR TITLE
fix: pin below ipyreact v0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "htmltools",
     "databackend",
-    "ipyreact",
+    "ipyreact<=0.4.1",
     "IPython",
     "importlib-metadata",
     "importlib-resources",


### PR DESCRIPTION
addresses widgets breaking on ipyreact v0.4.2, by pinning to the version below that for now. This was causing all doc examples to break.

See

https://github.com/widgetti/ipyreact/issues/66