### PR TITLE
fix: column default_sort_order respected when resorting

### DIFF
--- a/reactable/models.py
+++ b/reactable/models.py
@@ -795,7 +795,9 @@ class Column:
         if other is None:
             return self
 
-        field_attrs = {field.name: getattr(self, field.name) for field in fields(self)}
+        field_attrs = {
+            field.name: getattr(self, field.name) for field in fields(self) if field.init
+        }
         return replace(other, **filter_none(field_attrs))
 
     def to_props(self) -> dict[str, Any]:

--- a/reactable/models.py
+++ b/reactable/models.py
@@ -696,6 +696,9 @@ class Column:
     footer_style: CssRules | None = None
     id: str | None = None
 
+    # props ----
+    default_sort_desc: bool = field(init=False)
+
     # internal ----
     # TODO: ideally this cannot be specified in the constructor
     # it's just passed to the widget
@@ -713,6 +716,8 @@ class Column:
                 cell=self.format.to_props(),
                 aggregated=self.format.to_props(),
             )
+
+        self.default_sort_desc = self.default_sort_order == "desc"
 
     def _apply_transform(self, col_data: list[Any], transform: callable):
         return [


### PR DESCRIPTION
addresses #25 by adding a Column.default_sort_desc property. This means that...

* The Props (Table data) class still handles setting the initial sort order for columns.
* Columns now have the data to say what to do when a column is unsorted, and then sort is clicked.
  - e.g. Column A set to default to ascending order, AND it is initially sorted. If a person clicks Column B, it unsets the Column A sorting. Then, when they click Column A again, it should use the specified default and first do ascending.

Here's a demo of the fix using https://pr-26--react-tables-preview.netlify.app/get-started/controls-sorting#default-sort-order

**Initial**

<img width="812" alt="image" src="https://github.com/user-attachments/assets/7b35b21a-eb84-4498-aef5-7cfdcd0f5882">

**click sort by year**

<img width="820" alt="image" src="https://github.com/user-attachments/assets/6a9dc467-412f-4a62-9d94-86b428636517">

**click sort by species**

<img width="830" alt="image" src="https://github.com/user-attachments/assets/7e7d1f1c-1f0d-4144-a2ac-9cf2c780dbad">
