### PR TITLE
fix: ensure table default_sort_order respected

### DIFF
--- a/reactable/models.py
+++ b/reactable/models.py
@@ -697,7 +697,7 @@ class Column:
     id: str | None = None
 
     # props ----
-    default_sort_desc: bool = field(init=False)
+    default_sort_desc: bool | None = field(init=False)
 
     # internal ----
     # TODO: ideally this cannot be specified in the constructor
@@ -717,7 +717,10 @@ class Column:
                 aggregated=self.format.to_props(),
             )
 
-        self.default_sort_desc = self.default_sort_order == "desc"
+        if self.default_sort_order is not None:
+            self.default_sort_desc = self.default_sort_order == "desc"
+        else:
+            self.default_sort_desc = None
 
     def _apply_transform(self, col_data: list[Any], transform: callable):
         return [


### PR DESCRIPTION
This PR tweaks the previous fix in #25, to ensure...

* when default sorting order is  not set on a column, that
* table level default sorting is respected

Confirmed it works by clicking a column on https://pr-27--react-tables-preview.netlify.app/get-started/controls-sorting#default-sort-order and seeing it toggles to sort desc. Clicking species still defaults to asc (so no regression of original fix)