### PR TITLE
docs: clarify column class argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LIBRARY_DIR=$(PWD)/react_tables
+LIBRARY_DIR=$(PWD)/reactable
 REACTABLE_DIR=tmp/reactable
 
 all: react_tables/static/reactable-py.esm.js
@@ -8,16 +8,19 @@ setup:
 	git clone https://github.com/machow/reactable.git tmp/reactable
 
 docs-build:
-	cd docs && quarto render
+	cd docs \
+	  && quartodoc build --verbose \
+	  && quarto render
 
 docs-reference:
 	quartodoc build --config docs/_quarto.yml
 
-react_tables/static/reactable-py.esm.%: 
+reactable/static/reactable-py.esm.%: 
 	cd tmp/reactable
 	npx esbuild \
       $(REACTABLE_DIR)/srcjs/index2.js \
 	  --bundle --outfile=$(LIBRARY_DIR)/static/reactable-py.esm.js --format=esm \
 	  --external:react --external:react-dom --target=esnext \
 	  --loader:.js=jsx \
+	  --global-name=Reactable \
 	  --banner:js='import * as requireReact from "react"; import * as requireReactDom from "react-dom"; function require(m) { if (m === "react") return requireReact; if (m === "react-dom") return requireReactDom; throw new Error("Unknown module" + m); }'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,8 @@ extra = [
 dev = [
     "black",
     "jupyter",
-    "quartodoc>=0.7.1; python_version >= '3.9'",
+    "quartodoc>=0.9.1",
     "faicons",
-    "griffe==0.38.1",
     "great-tables",
     "mizani",
     "pandas",

--- a/reactable/models.py
+++ b/reactable/models.py
@@ -637,7 +637,9 @@ class Column:
         column stick to the left or right side. If a sticky column is in a column group, all columns
         in the group will automatically be made sticky, including the column group header.
     class_:
-        Additional CSS classes to apply to cells. Can also be a Python function that takes
+        Additional CSS classes to apply to cells. Multiple classes should be specied as a single
+        string with a space separating each class. If a list is passed, the first entry sets the
+        class for the first cell, and so on. Can also be a Python function that takes
         a `CellInfo()` object, or a `JS()` function that takes a row info object, column object,
         and table state object as arguments.
     style:


### PR DESCRIPTION
This PR tries to address #28 by clarifying what happens when `Column(class_=...)` receives a list