### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/docs/demos/pypi-downloads/fetch_data.py
+++ b/docs/demos/pypi-downloads/fetch_data.py
@@ -5,7 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 from io import StringIO
 
-r = requests.get("https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json")
+r = requests.get("https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json")
 r.raise_for_status()
 
 monthly = pl.DataFrame(r.json()["rows"]).rename(


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.